### PR TITLE
Remove Last Year's Sponsors Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
       </div>
     </div>
 
-    <h1>Last Year's Sponsors</h1>
+    <!-- <h1>Last Year's Sponsors</h1>
 
     <div class="sponsors">
       <div class="sponsor">
@@ -180,7 +180,7 @@
           <img class="animated bounce" src="img/bcs.jpg" alt="BCS">
       </div>
 
-    </div>
+    </div> -->
 
     <p>Interested in also being a sponsor? <a style="color: white;" href="mailto:president@hacs.tech?Subject=I%20want%20to%20sponsor%20BullHacks"><u>Drop us an email.</u></a></p>
 


### PR DESCRIPTION
I think the site is getting cluttered, and now most sponsor logos are there twice. As this is not a necessary change, don't feel compelled to approve it -  I just think it'll look nicer.